### PR TITLE
Don't die when parsing informational marks on the end of move strings.

### DIFF
--- a/src/position/mv.rs
+++ b/src/position/mv.rs
@@ -30,6 +30,8 @@ impl<const S: usize> Move<S> {
     }
 
     pub fn from_string(input: &str) -> Result<Self, pgn_traits::Error> {
+        // Trim informational marks
+        let input = input.trim_end_matches(['*', '?', '!', '\'']);
         if input.len() < 2 {
             return Err(pgn_traits::Error::new(
                 pgn_traits::ErrorKind::ParseError,

--- a/src/position/mv.rs
+++ b/src/position/mv.rs
@@ -30,8 +30,8 @@ impl<const S: usize> Move<S> {
     }
 
     pub fn from_string(input: &str) -> Result<Self, pgn_traits::Error> {
-        // Trim informational marks
-        let input = input.trim_end_matches(['*', '?', '!', '\'']);
+        // Trim crush notation
+        let input = input.trim_end_matches('*');
         if input.len() < 2 {
             return Err(pgn_traits::Error::new(
                 pgn_traits::ErrorKind::ParseError,


### PR DESCRIPTION
I encountered this issue via racetrack.  Basically, if an engine sends any informational marks on its move via `bestmove`, it forfeits the game with "\<color\> sent a malformed move".  I'd argue that something like `d2>*` is not malformed, and should be accepted.  Whether the stripping should occur here or within racetrack before this parsing takes place is a different consideration, but I opened this PR to address this error-causing situation that I don't think is quite right.